### PR TITLE
Target .NET 4.5 on App.Metrics.Abstractions

### DIFF
--- a/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
+++ b/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>Provides useful structures for performing efficient concurrent operations. Original Project: https://github.com/etishor/ConcurrencyUtilities, including a port of Java's LongAdder and Striped64 classes</Description>
     <AssemblyTitle>App.Metrics.Concurrency</AssemblyTitle>
-    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <AssemblyName>App.Metrics.Concurrency</AssemblyName>
     <PackageId>App.Metrics.Concurrency</PackageId>
     <PackageTags>Concurrency;Atomic</PackageTags>

--- a/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
+++ b/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
@@ -5,7 +5,8 @@
   <PropertyGroup>
     <Description>Provides useful structures for performing efficient concurrent operations. Original Project: https://github.com/etishor/ConcurrencyUtilities, including a port of Java's LongAdder and Striped64 classes</Description>
     <AssemblyTitle>App.Metrics.Concurrency</AssemblyTitle>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.1</TargetFrameworks>
     <AssemblyName>App.Metrics.Concurrency</AssemblyName>
     <PackageId>App.Metrics.Concurrency</PackageId>
     <PackageTags>Concurrency;Atomic</PackageTags>


### PR DESCRIPTION
### The issue or feature being addressed
Discussed on https://github.com/AppMetrics/AppMetrics/issues/245.

### Details on the issue fix or feature implementation
This changes the App.Metrics.Concurrency package to target both .NET Standard and .NET Framework in order to reduce the number of dependencies installed in framework projects.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits 